### PR TITLE
Added logic to choosing account and instance 

### DIFF
--- a/metrics.html
+++ b/metrics.html
@@ -225,39 +225,31 @@
     
     <!-- New Left Panel Feature -->
     <div class="toggle-btn" onclick="toggleSidePanel()">☰</div>
-    <div class="side-panel" id="sidePanel">
+    <div class="side-panel active" id="sidePanel">
         <br> 
         <br>
         <img src="https://cskcustomer1.s3.us-east-1.amazonaws.com/cdw-2023-Red-Panel.png" alt="CDW Logo">
         <br>
         <br>
         <!-- Accounts Section -->
-        <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Accounts
-        </button>
+        <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="awsAccountName">Accounts</button>
         <div class="dropdown-menu">
-            <button class="dropdown-item" onclick="selectAccount('Alpha')">Denver</button>
-            <button class="dropdown-item" onclick="selectAccount('Beta')">California</button>
-            <button class="dropdown-item" onclick="selectAccount('Gamma')">Omaha</button>
-        </div>
-        <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Instances
-        </button>
-        <div class="dropdown-menu">
-            <button class="dropdown-item" onclick="selectAccount('Alpha')">Instance 1</button>
-            <button class="dropdown-item" onclick="selectAccount('Beta')">Instance 2</button>
+            <button class="dropdown-item" onclick="selectAccount(event)">MAS Sandbox Development</button>
+            <button class="dropdown-item" onclick="selectAccount(event)">MAS Sandbox Test1</button>
+            <button class="dropdown-item" onclick="selectAccount(event)">MAS Sandbox Test2</button>
         </div>
         <div id="connectInstances"></div>
+        <h5 id="awsConnectInstanceName" class="mt-3"></h5>
 
-        <button class="btn btn-primary btn-block mt-2">Go</button>
+        <button class="btn btn-primary btn-block mt-2" id="getMetricsButton" disabled>Go</button>
 
         <!-- Dashboards Section -->
         <button class="btn btn-secondary btn-block mt-3" onclick="showDashboards()">Dashboards</button>
-        <i class="fas fa-plus add-icon" onclick="createNewDashboard()"></i>
+        <i class="fas fa-plus add-icon d-flex" onclick="createNewDashboard()"></i>
 
         <!-- Alarms Section -->
         <button class="btn btn-secondary btn-block mt-3" onclick="showAlarms()">Alarms</button>
-        <i class="fas fa-plus add-icon" onclick="createNewAlarm()"></i>
+        <i class="fas fa-plus add-icon d-flex" onclick="createNewAlarm()" style="text-align:center"></i>
     </div>
 
     <!-- Existing Logout Link -->
@@ -269,16 +261,68 @@
             sidePanel.classList.toggle('active');
         }
 
-        function selectAccount(account) {
+        function accountsAndConnectInstancesObject() {
+            const allAccountsList = [
+                {
+                    "MAS Sandbox Development": {
+                        "masdevelopment": "08aaaa8c-2bbf-4571-8570-f853f6b7dba0",
+                        "masdevelopmentinstance2": "5c1408e0-cd47-4ba9-9b0c-c168752e2285",
+                    }
+                },
+                {
+                    "MAS Sandbox Test1": {
+                        "mastest1instance2": "921b9e21-6d50-4365-b861-297f61227bb8",
+                        "mastest1": "cd54d26a-fee3-4645-87da-6acae50962a5"
+                    }
+                },
+                {
+                    "MAS Sandbox Test2": {
+                        "mastest2instance2": "d8445c54-35f2-4e65-ab0f-9c98889bdb0c",
+                        "mastest2": "ce2575a1-6ad8-4694-abd6-53acf392c698"
+                    }
+                }
+            ]
+            return allAccountsList;
+        }
+
+        function selectAccount(event) {
             const connectInstances = document.getElementById('connectInstances');
+            let instanceName = document.querySelector("#awsConnectInstanceName");
+            instanceName.innerHTML = "";
+            let finalAccountAndInstanceButton = document.querySelector("#getMetricsButton");
+            finalAccountAndInstanceButton.disabled = true;
+
+            let title = event.target.innerHTML;
             connectInstances.innerHTML = `
-                <h5 class="mt-3">${account} Instances</h5>
-                <div class="dropdown-menu">
-                    <button class="dropdown-item">Instance 1</button>
-                    <button class="dropdown-item">Instance 2</button>
-                    <button class="dropdown-item">Instance 3</button>
-                </div>
+                <h5 class="mt-3" id="awsAccountName">${title} Instances</h5>
+                <button class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Instances</button>
+                <div class="dropdown-menu instanceList"></div>
             `;
+            let allAccountsList = accountsAndConnectInstancesObject();
+            let instanceList = document.querySelector(".instanceList");
+            for (let i = 0; i < allAccountsList.length; i ++) {
+                let accountName = Object.keys(allAccountsList[i])[0]
+                if (accountName === title) {
+                    for (let [connectInstanceName, connectInstanceId] of Object.entries(allAccountsList[i][accountName])) {
+                        let button = document.createElement("button");
+                        button.classList.add("dropdown-item");
+                        button.classList.add("connectInstance")
+                        button.innerHTML = connectInstanceName;
+                        button.dataset.instanceId = connectInstanceId;
+                        button.addEventListener("click", selectInstance)
+                        instanceList.appendChild(button)
+                    }
+                }
+            }
+        }
+
+        
+
+        function selectInstance(event) {
+            let instanceNameSpace = document.querySelector("#awsConnectInstanceName");
+            instanceNameSpace.innerHTML = event.target.innerHTML;
+            let finalAccountAndInstanceButton = document.querySelector("#getMetricsButton");
+            finalAccountAndInstanceButton.disabled = false;
         }
 
         function showDashboards() {


### PR DESCRIPTION
To where all our aws accounts are hard coded into the accounts dropdown, and all connect instances are hard coded into the instance dropdown, but are dynamic, meaning if you choose 1 account, you will only get choices for instances underneath that account. Added logic to disable button unless both account and instance are chosen, then the Go button is enabled. Put plus signs in the center. Also modified the API gateway to include 2 more pathways, linked to 2 different lambdas, one to get contact flow names in an instance, and one to get queue names in an instance.