### PR TITLE
Merged timezone dropdown logic

### DIFF
--- a/metrics.html
+++ b/metrics.html
@@ -118,28 +118,6 @@
                 </section>
             </div>
         </div>
-        <!-- <div class="row justify-content-center">
-                <div class="col">
-                    <form>
-                        <div class="form-group">
-                        <label for="timeframeLength">Duration:</label>
-                        <input type="number" min="1" max="100" onkeypress="return event.charCode >= 48" class="form-control" id="timeframeLength" aria-describedby="timeframeLength" placeholder="2" oninput="enableButton()">
-                        </div>
-                    </form>
-                </div>
-                <div class="col">
-                    <label for="timeframeUnit">Unit of time:</label>
-                    <select name="timeframeUnit" id="timeframeUnit" class="custom-select">
-                        <option selected>Weeks</option>
-                        <option value="minutes">Minutes</option>
-                        <option value="hours">Hours</option>
-                        <option value="days">Days</option>
-                    </select>
-                </div>
-                <div class="col" style="display: flex; justify-content: center; align-items: center;">
-                    <button type="button" class="btn btn-secondary btn-block" style="margin-top: 13px;" id="customTimeButton" onClick="submitCustomTimeframe()" disabled>Go</button>
-                </div>
-        </div> -->
         <div class="row justify-content-center align-items-center flex-wrap">
             <div class="col d-flex">
                 <label for="customStartDate">Start Date</label>
@@ -156,8 +134,14 @@
             <div class="col d-flex dropdown">
                 <button class="btn btn-info dropdown-toggle" type="button" id="timezoneButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">UTC Timezone</button>
                   <div class="dropdown-menu" aria-labelledby="timezoneButton">
-                    <button class="dropdown-item"  type="button" onclick="timezoneDropdownChoice(event)">Local Timezone</button>
-                    <button class="dropdown-item" type="button" onclick="timezoneDropdownChoice(event)">UTC Timezone</button>
+                    <button class="dropdown-item"  type="button" onclick="timezoneDropdownChoice(event)">UTC Timezone</button>
+                    <button class="dropdown-item" type="button" onclick="timezoneDropdownChoice(event)">Local Timezone</button>
+                    <button class="dropdown-item" type="button" onclick="timezoneDropdownChoice(event)">Hawaii Time</button>
+                    <button class="dropdown-item" type="button" onclick="timezoneDropdownChoice(event)">Alaska Time</button>
+                    <button class="dropdown-item" type="button" onclick="timezoneDropdownChoice(event)">Pacific Time</button>
+                    <button class="dropdown-item" type="button" onclick="timezoneDropdownChoice(event)">Mountain Time</button>
+                    <button class="dropdown-item" type="button" onclick="timezoneDropdownChoice(event)">Central Time</button>
+                    <button class="dropdown-item" type="button" onclick="timezoneDropdownChoice(event)">Eastern Time</button>
                   </div>
             </div>
             <div class="col d-flex dropdown">
@@ -241,7 +225,7 @@
         <div id="connectInstances"></div>
         <h5 id="awsConnectInstanceName" class="mt-3"></h5>
 
-        <button class="btn btn-primary btn-block mt-2" id="getMetricsButton" disabled>Go</button>
+        <button class="btn btn-primary btn-block mt-2" id="getMetricsButton" onclick="sendInstanceId(event)" disabled>Go</button>
 
         <!-- Dashboards Section -->
         <button class="btn btn-secondary btn-block mt-3" onclick="showDashboards()">Dashboards</button>
@@ -265,20 +249,29 @@
             const allAccountsList = [
                 {
                     "MAS Sandbox Development": {
-                        "masdevelopment": "08aaaa8c-2bbf-4571-8570-f853f6b7dba0",
-                        "masdevelopmentinstance2": "5c1408e0-cd47-4ba9-9b0c-c168752e2285",
+                        "connectInstances": {
+                            "masdevelopment": "08aaaa8c-2bbf-4571-8570-f853f6b7dba0",
+                            "masdevelopmentinstance2": "5c1408e0-cd47-4ba9-9b0c-c168752e2285"
+                        },
+                        "baseAPIGatewayURL": "https://szw9nl20j5.execute-api.us-east-1.amazonaws.com/test"
                     }
                 },
                 {
                     "MAS Sandbox Test1": {
-                        "mastest1instance2": "921b9e21-6d50-4365-b861-297f61227bb8",
-                        "mastest1": "cd54d26a-fee3-4645-87da-6acae50962a5"
+                        "connectInstances": {
+                            "mastest1instance2": "921b9e21-6d50-4365-b861-297f61227bb8",
+                            "mastest1": "cd54d26a-fee3-4645-87da-6acae50962a5"
+                        },
+                        "baseAPIGatewayURL": "https://8vauowiu26.execute-api.us-east-1.amazonaws.com/test"
                     }
                 },
                 {
                     "MAS Sandbox Test2": {
-                        "mastest2instance2": "d8445c54-35f2-4e65-ab0f-9c98889bdb0c",
-                        "mastest2": "ce2575a1-6ad8-4694-abd6-53acf392c698"
+                        "connectInstances": {
+                            "mastest2instance2": "d8445c54-35f2-4e65-ab0f-9c98889bdb0c",
+                            "mastest2": "ce2575a1-6ad8-4694-abd6-53acf392c698"
+                        },
+                        "baseAPIGatewayURL": "placeholderURL"
                     }
                 }
             ]
@@ -303,12 +296,13 @@
             for (let i = 0; i < allAccountsList.length; i ++) {
                 let accountName = Object.keys(allAccountsList[i])[0]
                 if (accountName === title) {
-                    for (let [connectInstanceName, connectInstanceId] of Object.entries(allAccountsList[i][accountName])) {
+                    for (let [connectInstanceName, connectInstanceId] of Object.entries(allAccountsList[i][accountName]["connectInstances"])) {
                         let button = document.createElement("button");
                         button.classList.add("dropdown-item");
                         button.classList.add("connectInstance")
                         button.innerHTML = connectInstanceName;
                         button.dataset.instanceId = connectInstanceId;
+                        button.dataset.baseApiUrl = allAccountsList[i][accountName]["baseAPIGatewayURL"];
                         button.addEventListener("click", selectInstance)
                         instanceList.appendChild(button)
                     }
@@ -320,8 +314,12 @@
 
         function selectInstance(event) {
             let instanceNameSpace = document.querySelector("#awsConnectInstanceName");
+            let instanceId = event.target.dataset.instanceId
+            let apiUrl = event.target.dataset.baseApiUrl;
             instanceNameSpace.innerHTML = event.target.innerHTML;
             let finalAccountAndInstanceButton = document.querySelector("#getMetricsButton");
+            finalAccountAndInstanceButton.dataset.instanceId = instanceId
+            finalAccountAndInstanceButton.dataset.baseApiUrl = apiUrl
             finalAccountAndInstanceButton.disabled = false;
         }
 
@@ -339,6 +337,13 @@
 
         function createNewAlarm() {
             alert('Creating a new alarm...');
+        }
+        window.onload = () => {
+            if (window.location.hash) {
+                let hash = window.location.hash;
+                let token = hash.split("access_token=")[1].split("&")[0];
+                sessionStorage.setItem("MetricVisionAccessToken", token)
+            }
         }
     </script>
 


### PR DESCRIPTION
Now can toggle between timezones for metrics. Changed hard coded sturcture of account names and connect instances to be more nested and to include their respective api gateway base url. Added lambda functions for get contact flow names and  queue names and new api gateway in sandbox and test1 aws accounts, so now can fetch data respective of connect instances from those accounts, need to do for test2 aws account as well. Next steps would be to make lambda code with all individual metrics that you want, and then make changes in front end for picking which individual metrics you want. How fetch requests for contact flow name and queue work are when user chooses go after selecting their account and instance, those query in the background while the user selects their times, timezone, etc. When they are finished, the different contact flow names and queue names will be available for picking in the dropdowns, however the code takes about 3 seconds to run currently I am not sure why