### PR TITLE
Fixed dates coming back as 2001 on high interval selection

### DIFF
--- a/metrics.html
+++ b/metrics.html
@@ -265,11 +265,7 @@
             <div class="d-flex justify-content-start input-wrapper timezone-dropdown">
                 <label class="mr-1">Timezone</label>
                 <div class="dropdown">
-                    <button class="btn btn-info dropdown-toggle" type="button" id="timezoneButton"
-                        style="padding: 5px; width: 250px; height: 38px;" data-toggle="dropdown"
-                        aria-haspopup="true" aria-expanded="false">
-                        Select
-                    </button>
+                    <button class="btn btn-info dropdown-toggle" type="button" id="timezoneButton" style="padding: 5px; width: 250px; height: 38px;" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Local Timezone</button>
                     <div class="dropdown-menu" aria-labelledby="timezoneButton">
                         <button class="dropdown-item" type="button" onclick="timezoneDropdownChoice(event)">UTC Timezone</button>
                         <button class="dropdown-item" type="button" onclick="timezoneDropdownChoice(event)">Local Timezone</button>

--- a/metrics.js
+++ b/metrics.js
@@ -442,7 +442,7 @@ async function handlePeriodChange(e) {
     let timezoneChoice = document.querySelector("#timezoneButton").innerHTML;
     let localTimezoneChoice = timezoneChoice.split(" ")[0];
     let formatterOptions = {
-        year: "numeric",
+        year: "2-digit",
         month: "2-digit",
         day: "2-digit",
         hour: "2-digit",
@@ -489,7 +489,7 @@ async function handlePeriodChange(e) {
         for (let i = 0; i < metricDataResults; i++) {
             createTableLineGauge(data.data.MetricDataResults[i])
         }
-        createIcons();
+        // createIcons();
     }
 }
 
@@ -643,10 +643,30 @@ function createLineGraphNew(data, container) {
             chartMetricData.push(chartData)
         }
     }
+    const metricUnitConversion = {
+        "Calls": ["calls_per_interval","missed_calls","concurrent_calls","calls_breaching_concurrency_quota","call_recording_upload_error", "queue_capacity_exceeded_error", "throttled_calls", "calls_transferred_to_agent"],
+        "Percentage": ["concurrent_calls_percentage", "to_instance_packet_loss_rate", "forecast_accuracy", "schedule_adherence", "concurrent_tasks_percentage", "concurrent_emails_percentage", "concurrent_active_chats_percentage"],
+        "Errors": ["contact_flow_errors", "contact_flow_fatal_errors"],
+        "Seconds": ["longest_queue_wait_time", "api_latency"],
+        "Contacts": ["queue_size"],
+        "Score": ["contact_lens_sentiment"],
+        "Count": ["api_request_count", "api_error_count"],
+        "Usage": ["wisdom_knowledge_article_usage"],
+        "Suggestions": ["wisdom_assist_suggestions"],
+        "Tasks": ["tasks_expiry_warning_reached", "tasks_expired", "tasks_breaching_concurrency_quota", "concurrent_tasks"],
+        "Chats": ["successful_chats_per_interval", "concurrent_active_chats", "chats_breaching_active_chat_quota"],
+        "Emails": ["concurrent_emails"]
+    }
+    let yAxisTitle;
+    for (const [key,values] of Object.entries(metricUnitConversion)) {
+        if (values.includes(metric)) {
+            yAxisTitle = key
+        }
+    }
     let graphData = {
         "title": metric,
         "xAxis": "Interval",
-        "yAxis": metric,
+        "yAxis": yAxisTitle,
         "data": chartMetricData
     }
     chartLineGraph(graphData, container)
@@ -656,10 +676,25 @@ function chartLineGraph(graphData, container) {
     let {title, xAxis, yAxis, data} = graphData;
     let chart = anychart.line();
     chart.data(data);
-    chart.title(cleanMetricName(title));
+    let chartTitle = chart.title();
+    chartTitle.enabled(true);
+    chartTitle.useHtml(true);
+    chartTitle.text(`<b>${cleanMetricName(title)}</b>`)
+
+    //Floating Tooltip
+    if (data.length > 0) {
+        let tooltip = chart.getSeries(0).tooltip();
+        if (yAxis === "Percentage") {
+            tooltip.format("{%value}%");
+        } else {
+            tooltip.format("{%value}");
+        }
+        
+    }
     
     // Step 5: Customize axes
-    chart.xAxis().title(xAxis);
+    // chart.xAxis().title(xAxis);
+    chart.yAxis().title(yAxis);
 
     let flexDiv = document.createElement("section");
     flexDiv.classList.add("flex-grow-1");
@@ -788,7 +823,7 @@ async function submitCustomDateTimeframe() {
     }
     let localTimezoneChoice = timezoneChoice.split(" ")[0];
     let formatterOptions = {
-        year: "numeric",
+        year: "2-digit",
         month: "2-digit",
         day: "2-digit",
         hour: "2-digit",
@@ -910,7 +945,7 @@ function refreshDropdownChoice(event) {
         let chosenMetrics = chooseMetrics();
         let localTimezoneChoice = timezoneChoice.split(" ")[0];
         let formatterOptions = {
-            year: "numeric",
+            year: "2-digit",
             month: "2-digit",
             day: "2-digit",
             hour: "2-digit",


### PR DESCRIPTION
I added a Y axis title to the line graphs that is dynamic to the specific metric, for example if the metric is calls per interval the y axis title will be Calls, if the metric is chats breaching active chat quota then the y axis title will be Chats etc. I stylized the titles of the graphs to be bold, I did not change the font or size or anything else. I changed the on hover of the graphs to just display the x and y values, and if the value is a percent, then the value will be the value plus the % sign, so it no longer says series 0:. I modified the html for the timezone button to on page load display the words Local Timezone instead of just select, since the default option if you don't choose a timezone is the local timezone. The option still changes based on whatever you choose from the dropdown, so if you choose Eastern Timezone, it will say that. On the changing interval dropdown, the code was written to erase the interval dropdown and all the icons and make them new again programmatically. This meant that when you chose an interval like 15 minutes, when the fetch request was done and the graphs loaded, the icons would be deleted and made again, and the interval dropdown would be deleted and made again. I commented out this function call so now that when you choose an interval, the buttons remain, and your choice remains on the dropdown so you can see if you have chosen 15 minutes or 1 hour etc. I have also Fixed the problem with the intervals showing 2001 if you choose 7 days etc. Now all dates on the graphs are in a 2 digit year format, and all come back with the expected values no matter the interval you select